### PR TITLE
simpler filter list display, changed nameMap.js

### DIFF
--- a/services/nameMap.js
+++ b/services/nameMap.js
@@ -3,38 +3,66 @@
    to the right side. */
    
 const nameMap = {
+   // New Player1 Focused Map
+    "player1ServePlacement"  : 'Serve Placement',
+    "player1ServeResult"     : 'Serve Result',
+
+    "player1ReturnPlacement" : 'Return Placement',
+    "player1ReturnFhBh"      : 'Return Forehand/Backhand',
+    "player1LastShotResult"  : 'Winner/Error',
+
+    "player1LastShotPlacement" : 'Last Shot Placement',
+    "player1LastShotPlacementFhBh" : 'Last Shot Forehand/Backhand',
+
+    "rallyCountFreq"         : 'Rally Length',
+    "atNetPlayer1"           : 'At Net',
+    "pointWonBy"             : 'Point Won By',
+    "side"                   : 'Duece/Ad Side',
+    "setNum"                 : 'Set Number',
+   
+
+
+
 
     // Data Version 0 (Points)
-    "point_winner"           : 'Point Winner',
+   //  "point_winner"           : 'Point Winner',
 
-    "serverName"             : 'Server',
-    "Serve Result"           : 'Serve Result',
-    "Serve Placement"        : 'Serve Placement',
-    "servingSide"            : 'Duece/Ad Side',
+   //  "serverName"             : 'Server',
+   //  "Serve Result"           : 'Serve Result',
+   //  "Serve Placement"        : 'Serve Placement',
+   //  "servingSide"            : 'Duece/Ad Side',
 
-    "returnerName"           : 'Returner',
-    "Return (Forehand/Backhand)": 'Return (Forehand/Backhand)',
-    "Return Placement"       : 'Return Placement',
-    "Return Error Type"      : 'Return Error Type',
+   //  "returnerName"           : 'Returner',
+   //  "Return (Forehand/Backhand)": 'Return (Forehand/Backhand)',
+   //  "Return Placement"       : 'Return Placement',
+   //  "Return Error Type"      : 'Return Error Type',
 
-    "Serve +1 Forehand/Backhand" : 'Serve +1 Forehand/Backhand',
-    "Serve +1 Placement"     : 'Serve +1 Placement',
-    "Serve +1 Error Type"    : 'Serve +1 Error Type',
+   //  "Serve +1 Forehand/Backhand" : 'Serve +1 Forehand/Backhand',
+   //  "Serve +1 Placement"     : 'Serve +1 Placement',
+   //  "Serve +1 Error Type"    : 'Serve +1 Error Type',
 
-   //  "Return +1 Forehand/Backhand" : 'Return +1 Forehand/Backhand',
-   //  "Return +1 Placement"    : 'Return +1 Placement',
-   //  "Return +1 Error Type"   : 'Return +1 Error Type',
+   // //  "Return +1 Forehand/Backhand" : 'Return +1 Forehand/Backhand',
+   // //  "Return +1 Placement"    : 'Return +1 Placement',
+   // //  "Return +1 Error Type"   : 'Return +1 Error Type',
 
-    "Last Shot Forehand/Backhand" : 'Last Shot Forehand/Backhand',
-    "Last Shot Placement"    : 'Last Shot Placement',
-    "Last Shot Error Type"   : 'Last Shot Error Type',
+   //  "Last Shot Forehand/Backhand" : 'Last Shot Forehand/Backhand',
+   //  "Last Shot Placement"    : 'Last Shot Placement',
+   //  "Last Shot Error Type"   : 'Last Shot Error Type',
 
-    "atNetName"                  : 'At Net',
-    "isbreakPoint"           : 'Break Point',
-    "setScoreSum"            : 'Set #',
-    "rallyCountFreq"         : 'Rally Length',
+   //  "atNetName"                  : 'At Net',
+   //  "isbreakPoint"           : 'Break Point',
+   //  "setScoreSum"            : 'Set #',
+   //  "rallyCountFreq"         : 'Rally Length',
     
 
+
+
+  
+
+
+
+    
+    
     // Data Version 1
     // "Name"                   : 'Point Score',
     "Shot 1: gameScore"      : 'Game Score',


### PR DESCRIPTION
Commented out old name map. Added new name map so that filterable columns are focused on events associated with only player 1. For instance, Serve Result only shows Serve Result when Player 1 is Serving. Such that our UCLA Players should always be player 1 and they can directly access their points. 

Potential Issues:
If we are scouting or want to view the other players, there should be alternative nameMap or option to switch to other columns that focus on player2