### PR TITLE
Added changes to filterlist, nameMap. Small changes

### DIFF
--- a/app/components/FilterList.js
+++ b/app/components/FilterList.js
@@ -6,15 +6,16 @@ import styles from '../styles/FilterList.module.css';
 import nameMap from '../services/nameMap.js';
 
 const FilterList = ({ pointsData, filterList, setFilterList, showPercent, showCount }) => {
-  // only keep relevant keys
-  const keys = Object.keys(nameMap).filter(key => pointsData && pointsData.some(point => Object.prototype.hasOwnProperty.call(point, key)));
-  const uniqueValues = {};
 
-  // Iterate through filtered keys and populate uniqueValues
-  keys.forEach((key) => {
+  // only keep relevant keys 
+  const keys = Object.keys(nameMap).filter(key => pointsData && pointsData.some(point => point.hasOwnProperty(key))); 
+  const uniqueValues = {}; 
+  
+  // Iterate through filtered keys and populate uniqueValues 
+  keys.forEach((key) => { 
     uniqueValues[key] = [...new Set(pointsData.map((point) => point[key]))].sort();
   });
-    
+
   // State for the open key
   const [openKey, setOpenKey] = useState(null);
 

--- a/app/services/nameMap.js
+++ b/app/services/nameMap.js
@@ -1,8 +1,11 @@
 /* Usage: If you want to change the name of a column in the filter list, 
    add the original column name to the left side and the display name
    to the right side. */
-   
+ 
 const nameMap = {
+
+   
+
   // New Player1 Focused Map
   "player1ServePlacement"  : 'Serve Placement',
   "player1ServeResult"     : 'Serve Result',
@@ -19,11 +22,16 @@ const nameMap = {
     
   //Group 4: Point Information
   "rallyCountFreq"         : 'Rally Length',
-  "atNetPlayer1"           : 'Player At Net',
+  "atNetPlayer1"           : 'Player Comes to Net',
   "pointWonBy"             : 'Point Won By',
-  "side"                   : 'Duece/Ad Side',
+  "side"                   : 'Deuce/Ad Side',
   "setNum"                 : 'Set Number',
-   
+
+  //Group 5: Special Requests
+  "isPressurePoint"        : " Pressure Point",
+  "isUnforcedError"        : "Unforced Error",
+  "isSecondServeAttacked"  : "Second Serve Attacked",
+  "isAggressiveServePlusOne"  : "Aggressive Serve +1",
 
 
 


### PR DESCRIPTION
Changed filterlist using @Fredenck code. Now doesn't show columns that are not present in data.

Added backup columns from player's request such as watching when second serve is attacked or aggressive serve + 1. Which should only show up if in special tagger. Need to communicate to @cardo14 to make sure these columns are not in regular matches otherwise they will be blank on match viewer.