### PR TITLE
Firebase reformat

### DIFF
--- a/app/(interactive)/upload-match/page.js
+++ b/app/(interactive)/upload-match/page.js
@@ -66,6 +66,7 @@ export default function UploadVideo() {
   const clientPlayerOptions = useMemo(() => {
     const team = teams.find(team => team.name === clientTeam);
     if (!team || !Object.prototype.hasOwnProperty.call(team, 'players')) return null; // Check if team or team.players doesn't exist
+    setClientPlayer(team.players[0]);
     return team.players.map(player => (
       <option key={player} value={player}>{player}</option>
     ));
@@ -73,6 +74,7 @@ export default function UploadVideo() {
   const opponentPlayerOptions = useMemo(() => {
     const team = teams.find(team => team.name === opponentTeam);
     if (!team || !Object.prototype.hasOwnProperty.call(team, 'players')) return null; // Check if team or team.players doesn't exist
+    setOpponentPlayer(team.players[0]);
     return team.players.map(player => (
       <option key={player} value={player}>{player}</option>
     ));

--- a/app/(interactive)/upload-match/page.js
+++ b/app/(interactive)/upload-match/page.js
@@ -63,16 +63,14 @@ export default function UploadVideo() {
   const clientPlayerOptions = useMemo(() => {
     console.log(clientTeam)
     const team = teams.find(team => team.name === clientTeam);
-    console.log(team)
-    if (!team) return null
-    console.log(team)
+    if (!team || !Object.prototype.hasOwnProperty.call(team, 'players')) return null; // Check if team or team.players doesn't exist
     return team.players.map(player => (
       <option key={player} value={player}>{player}</option>
     ));
   }, [clientTeam, teams]);
   const opponentPlayerOptions = useMemo(() => {
     const team = teams.find(team => team.name === opponentTeam);
-    if (!team) return null
+    if (!team || !Object.prototype.hasOwnProperty.call(team, 'players')) return null; // Check if team or team.players doesn't exist
     return team.players.map(player => (
       <option key={player} value={player}>{player}</option>
     ));
@@ -117,17 +115,17 @@ export default function UploadVideo() {
           </label>
           <label>
             <input
-            type="radio"
-            checked={singles}
-            onChange={() => {setSingles(true)}}
+              type="radio"
+              checked={singles}
+              onChange={() => {setSingles(true)}}
             />
             Singles
           </label>
           <label>
             <input
-            type="radio"
-            checked={!singles}
-            onChange={() => {setSingles(false)}}
+              type="radio"
+              checked={!singles}
+              onChange={() => {setSingles(false)}}
             />
             Doubles
           </label>

--- a/app/(interactive)/upload-match/page.js
+++ b/app/(interactive)/upload-match/page.js
@@ -59,6 +59,7 @@ export default function UploadVideo() {
   const teamOptions = useMemo(() => {
     if (teams.length === 0) return null;
     setClientTeam(teams[0].name);
+    setOpponentTeam(teams[0].name);
     return teams.map((option, index) => (
       <option key={index} value={option.name}>{option.name}</option>
     ));
@@ -84,7 +85,7 @@ export default function UploadVideo() {
     <div className={styles.container}>
       <div>
         <h1 className={styles.title}>Upload Match</h1>
-        <h3>Make sure you add the player in 'Upload Team' before this!</h3>
+        <h3>Make sure you add the player in &apos;Upload Team&apos; before this!</h3>
         <form className={styles.form} onSubmit={handleSubmit}>
           <label>
             Client Team: 

--- a/app/(interactive)/upload-match/page.js
+++ b/app/(interactive)/upload-match/page.js
@@ -11,9 +11,9 @@ export default function UploadVideo() {
   const [videoId, setVideoId] = useState('');
   const [jsonFile, setJsonFile] = useState(null);
   const [pdfFile, setPdfFile] = useState(null);
-  const [clientTeam, setClientTeam] = useState('Arizona (M)');
+  const [clientTeam, setClientTeam] = useState();
   const [clientPlayer, setClientPlayer] = useState(null);
-  const [opponentTeam, setOpponentTeam] = useState('Arizona (M)');
+  const [opponentTeam, setOpponentTeam] = useState();
   const [opponentPlayer, setOpponentPlayer] = useState(null);
   const [teams, setTeams] = useState([]);
   const [matchDate, setMatchDate] = useState('')
@@ -29,9 +29,7 @@ export default function UploadVideo() {
       }
     };
 
-    fetchTeams().then(() => {
-      setClientTeam('Arizona (M)'); setOpponentTeam('Arizona (M)')
-    });    
+    fetchTeams();    
   }, []);
 
   const handleSubmit = async (e) => {
@@ -59,6 +57,8 @@ export default function UploadVideo() {
   };
 
   const teamOptions = useMemo(() => {
+    if (teams.length === 0) return null;
+    setClientTeam(teams[0].name);
     return teams.map((option, index) => (
       <option key={index} value={option.name}>{option.name}</option>
     ));

--- a/app/(interactive)/upload-match/page.js
+++ b/app/(interactive)/upload-match/page.js
@@ -11,13 +11,11 @@ export default function UploadVideo() {
   const [videoId, setVideoId] = useState('');
   const [jsonFile, setJsonFile] = useState(null);
   const [pdfFile, setPdfFile] = useState(null);
-  const [clientTeam, setClientTeam] = useState('Arizona State (M)');
-  const [clientPlayer, setClientPlayer] = useState('Arizona State (M)');
-  const [opponentTeam, setOpponentTeam] = useState(null);
+  const [clientTeam, setClientTeam] = useState('Arizona (M)');
+  const [clientPlayer, setClientPlayer] = useState(null);
+  const [opponentTeam, setOpponentTeam] = useState('Arizona (M)');
   const [opponentPlayer, setOpponentPlayer] = useState(null);
   const [teams, setTeams] = useState([]);
-  const [clientPlayers, setClientPlayers] = useState([]);
-  const [opponentPlayers, setOpponentPlayers] = useState([]);
   const [singles, setSingles] = useState(true);
 
   useEffect(() => {
@@ -32,32 +30,6 @@ export default function UploadVideo() {
 
     fetchTeams();
   }, []);
-
-  useEffect(() => {
-    const fetchClientPlayers = async () => {
-      try {
-        const p = await getClientPlayers();
-        setClientPlayers(p);
-      } catch (error) {
-        console.error('Error fetching data:', error);
-      }
-    };
-
-    fetchClientPlayers();
-  }, [clientTeam]);
-
-  useEffect(() => {
-    const fetchOpponentPlayers = async () => {
-      try {
-        const p = await getClientPlayers();
-        setClientPlayers(p);
-      } catch (error) {
-        console.error('Error fetching data:', error);
-      }
-    };
-
-    fetchOpponentPlayers();
-  }, [opponentTeam]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -87,15 +59,20 @@ export default function UploadVideo() {
     ));
   }, [teams]);
   const clientPlayerOptions = useMemo(() => {
-    return clientPlayers.map((option, index) => (
-      <option key={index} value={option.name}>{option.name}</option>
+    if (teams.length === 0) return null
+    const team = teams.find(team => team.name === clientTeam);
+    console.log(team)
+    return team.players.map(player => (
+      <option key={player} value={player}>{player}</option>
     ));
-  }, [clientPlayers]);
+  }, [teams]);
   const opponentPlayerOptions = useMemo(() => {
-    return opponentPlayers.map((option, index) => (
-      <option key={index} value={option.name}>{option.name}</option>
+    if (teams.length === 0) return null
+    const team = teams.find(team => team.name === opponentTeam);
+    return team.players.map(player => (
+      <option key={player} value={player}>{player}</option>
     ));
-  }, [opponentPlayers]);
+  }, [teams]);
 
   return (
     <div className={styles.container}>

--- a/app/(interactive)/upload-match/page.js
+++ b/app/(interactive)/upload-match/page.js
@@ -28,7 +28,9 @@ export default function UploadVideo() {
       }
     };
 
-    fetchTeams();
+    fetchTeams().then(() => {
+      setClientTeam('Arizona (M)'); setOpponentTeam('Arizona (M)')
+    });    
   }, []);
 
   const handleSubmit = async (e) => {
@@ -59,20 +61,22 @@ export default function UploadVideo() {
     ));
   }, [teams]);
   const clientPlayerOptions = useMemo(() => {
-    if (teams.length === 0) return null
+    console.log(clientTeam)
     const team = teams.find(team => team.name === clientTeam);
+    console.log(team)
+    if (!team) return null
     console.log(team)
     return team.players.map(player => (
       <option key={player} value={player}>{player}</option>
     ));
-  }, [teams]);
+  }, [clientTeam, teams]);
   const opponentPlayerOptions = useMemo(() => {
-    if (teams.length === 0) return null
     const team = teams.find(team => team.name === opponentTeam);
+    if (!team) return null
     return team.players.map(player => (
       <option key={player} value={player}>{player}</option>
     ));
-  }, [teams]);
+  }, [opponentTeam, teams]);
 
   return (
     <div className={styles.container}>

--- a/app/(interactive)/upload-match/page.js
+++ b/app/(interactive)/upload-match/page.js
@@ -16,6 +16,8 @@ export default function UploadVideo() {
   const [opponentTeam, setOpponentTeam] = useState(null);
   const [opponentPlayer, setOpponentPlayer] = useState(null);
   const [teams, setTeams] = useState([]);
+  const [clientPlayers, setClientPlayers] = useState([]);
+  const [opponentPlayers, setOpponentPlayers] = useState([]);
   const [singles, setSingles] = useState(true);
 
   useEffect(() => {
@@ -30,6 +32,32 @@ export default function UploadVideo() {
 
     fetchTeams();
   }, []);
+
+  useEffect(() => {
+    const fetchClientPlayers = async () => {
+      try {
+        const p = await getClientPlayers();
+        setClientPlayers(p);
+      } catch (error) {
+        console.error('Error fetching data:', error);
+      }
+    };
+
+    fetchClientPlayers();
+  }, [clientTeam]);
+
+  useEffect(() => {
+    const fetchOpponentPlayers = async () => {
+      try {
+        const p = await getClientPlayers();
+        setClientPlayers(p);
+      } catch (error) {
+        console.error('Error fetching data:', error);
+      }
+    };
+
+    fetchOpponentPlayers();
+  }, [opponentTeam]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -58,6 +86,16 @@ export default function UploadVideo() {
       <option key={index} value={option.name}>{option.name}</option>
     ));
   }, [teams]);
+  const clientPlayerOptions = useMemo(() => {
+    return clientPlayers.map((option, index) => (
+      <option key={index} value={option.name}>{option.name}</option>
+    ));
+  }, [clientPlayers]);
+  const opponentPlayerOptions = useMemo(() => {
+    return opponentPlayers.map((option, index) => (
+      <option key={index} value={option.name}>{option.name}</option>
+    ));
+  }, [opponentPlayers]);
 
   return (
     <div className={styles.container}>

--- a/app/(interactive)/upload-match/page.js
+++ b/app/(interactive)/upload-match/page.js
@@ -12,8 +12,11 @@ export default function UploadVideo() {
   const [jsonFile, setJsonFile] = useState(null);
   const [pdfFile, setPdfFile] = useState(null);
   const [clientTeam, setClientTeam] = useState('Arizona State (M)');
-  const [opponentTeam, setOpponentTeam] = useState('Arizona State (M)');
+  const [clientPlayer, setClientPlayer] = useState('Arizona State (M)');
+  const [opponentTeam, setOpponentTeam] = useState(null);
+  const [opponentPlayer, setOpponentPlayer] = useState(null);
   const [teams, setTeams] = useState([]);
+  const [singles, setSingles] = useState(true);
 
   useEffect(() => {
     const fetchTeams = async () => {
@@ -76,10 +79,38 @@ export default function UploadVideo() {
             </select>
           </label>
           <label>
+            Client Player: 
+            <select id="search" onChange={(e) => setClientPlayer(e.target.value)}>
+              {clientPlayerOptions}
+            </select>
+          </label>
+          <label>
             Opponent Team: 
             <select id="search" onChange={(e) => setOpponentTeam(e.target.value)}>
               {teamOptions}
             </select>
+          </label>
+          <label>
+            Opponent Player: 
+            <select id="search" onChange={(e) => setOpponentPlayer(e.target.value)}>
+              {opponentPlayerOptions}
+            </select>
+          </label>
+          <label>
+            <input
+            type="radio"
+            checked={singles}
+            onChange={() => {setSingles(true)}}
+            />
+            Singles
+          </label>
+          <label>
+            <input
+            type="radio"
+            checked={!singles}
+            onChange={() => {setSingles(false)}}
+            />
+            Doubles
           </label>
           <label>
             JSON File: 

--- a/app/(interactive)/upload-match/page.js
+++ b/app/(interactive)/upload-match/page.js
@@ -7,7 +7,7 @@ import getTeams from '@/app/services/getTeams.js';
 import styles from '../../styles/Upload.module.css'
 
 export default function UploadVideo() {
-  const [matchName, setMatchName] = useState('');
+  const [matchScore, setMatchScore] = useState('');
   const [videoId, setVideoId] = useState('');
   const [jsonFile, setJsonFile] = useState(null);
   const [pdfFile, setPdfFile] = useState(null);
@@ -16,6 +16,7 @@ export default function UploadVideo() {
   const [opponentTeam, setOpponentTeam] = useState('Arizona (M)');
   const [opponentPlayer, setOpponentPlayer] = useState(null);
   const [teams, setTeams] = useState([]);
+  const [matchDate, setMatchDate] = useState('')
   const [singles, setSingles] = useState(true);
 
   useEffect(() => {
@@ -36,7 +37,7 @@ export default function UploadVideo() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     
-    if (!matchName || !videoId || !clientTeam || !opponentTeam) {
+    if (!matchScore || !videoId || !clientTeam || !opponentTeam || !clientPlayer || !opponentPlayer || !matchDate) {
       console.error("Please fill in all fields.");
       return;
     }
@@ -48,7 +49,9 @@ export default function UploadVideo() {
         const result = confirm("You're currently uploading an UNTAGGED match. Proceed?");
         if (!result) throw new Error("Upload cancelled by user.");
       }
-      await uploadMatch(matchName, videoId, pointsJson, pdfFile, clientTeam, opponentTeam);
+      const teams = [clientTeam, opponentTeam];
+      const players = [clientPlayer, opponentPlayer];
+      await uploadMatch(matchScore, videoId, pointsJson, pdfFile, teams, players, matchDate, singles);
       alert('done!')
     } catch (error) {
       console.error("Error uploading match:", error);
@@ -61,7 +64,6 @@ export default function UploadVideo() {
     ));
   }, [teams]);
   const clientPlayerOptions = useMemo(() => {
-    console.log(clientTeam)
     const team = teams.find(team => team.name === clientTeam);
     if (!team || !Object.prototype.hasOwnProperty.call(team, 'players')) return null; // Check if team or team.players doesn't exist
     return team.players.map(player => (
@@ -81,14 +83,6 @@ export default function UploadVideo() {
       <div>
         <h1 className={styles.title}>Upload Match</h1>
         <form className={styles.form} onSubmit={handleSubmit}>
-          <label>
-            Match Name: 
-            <input type="text" value={matchName} onChange={(e) => setMatchName(e.target.value)} />
-          </label>
-          <label>
-            Video ID: 
-            <input type="text" value={videoId} onChange={(e) => setVideoId(e.target.value)} />
-          </label>
           <label>
             Client Team: 
             <select id="search" onChange={(e) => setClientTeam(e.target.value)}>
@@ -112,6 +106,22 @@ export default function UploadVideo() {
             <select id="search" onChange={(e) => setOpponentPlayer(e.target.value)}>
               {opponentPlayerOptions}
             </select>
+          </label>
+          <label>
+            Match Score (spaces only between sets): 7-4 6-7(0-7) 7-2(13-11): 
+          </label>
+          <input type="text" value={matchScore} onChange={(e) => setMatchScore(e.target.value)} />
+          <label htmlFor="date">Date:
+            <input
+              type="date"
+              id="date"
+              value={matchDate}
+              onChange={(e) => {setMatchDate(e.target.value)}}
+            />
+          </label>
+          <label>
+            Video ID: 
+            <input type="text" value={videoId} onChange={(e) => setVideoId(e.target.value)} />
           </label>
           <label>
             <input

--- a/app/(interactive)/upload-match/page.js
+++ b/app/(interactive)/upload-match/page.js
@@ -84,6 +84,7 @@ export default function UploadVideo() {
     <div className={styles.container}>
       <div>
         <h1 className={styles.title}>Upload Match</h1>
+        <h3>Make sure you add the player in 'Upload Team' before this!</h3>
         <form className={styles.form} onSubmit={handleSubmit}>
           <label>
             Client Team: 

--- a/app/(interactive)/upload-team/page.js
+++ b/app/(interactive)/upload-team/page.js
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { uploadTeam, uploadPlayer } from '../../services/upload.js';
 import getTeams from '@/app/services/getTeams.js';
 
@@ -8,6 +8,7 @@ import styles from '../../styles/Upload.module.css'
 
 export default function UploadVideo() {
   const [teamName, setTeamName] = useState('');
+  const [teamSelect, setTeamSelect] = useState('Arizona (M)')
   const [playerName, setPlayerName] = useState('');
   const [logoFile, setLogoFile] = useState(null);
   const [teams, setTeams] = useState([]);
@@ -46,18 +47,24 @@ export default function UploadVideo() {
   const handleAddSubmit = async (e) => {
     e.preventDefault();
     
-    if (!playerName) {
+    if (!playerName || !teamSelect) {
       console.error("Please fill in Player Name.");
       return;
     }
     
     try {
-      await uploadPlayer(playerName)
+      await uploadPlayer(playerName, teamSelect)
       alert('done!')
     } catch (error) {
       console.error("Error uploading match:", error);
     }
   };
+
+  const teamOptions = useMemo(() => {
+    return teams.map((option, index) => (
+      <option key={index} value={option.name}>{option.name}</option>
+    ));
+  }, [teams]);
 
   return (
     <div className={styles.container}>
@@ -88,7 +95,13 @@ export default function UploadVideo() {
         <form className={styles.form} onSubmit={handleAddSubmit}>
           <label>
             Player Name: 
-            <input type="text" value={teamName} onChange={(e) => setPlayerName(e.target.value)} />
+            <input type="text" value={playerName} onChange={(e) => setPlayerName(e.target.value)} />
+          </label>
+          <label>
+            Team: 
+            <select id="search" onChange={(e) => setTeamSelect(e.target.value)}>
+              {teamOptions}
+            </select>
           </label>
           <button type="submit">Add</button>
         </form>

--- a/app/(interactive)/upload-team/page.js
+++ b/app/(interactive)/upload-team/page.js
@@ -1,13 +1,14 @@
 'use client'
 
 import React, { useState, useEffect } from 'react';
-import { uploadTeam } from '../../services/upload.js';
+import { uploadTeam, uploadPlayer } from '../../services/upload.js';
 import getTeams from '@/app/services/getTeams.js';
 
 import styles from '../../styles/Upload.module.css'
 
 export default function UploadVideo() {
   const [teamName, setTeamName] = useState('');
+  const [playerName, setPlayerName] = useState('');
   const [logoFile, setLogoFile] = useState(null);
   const [teams, setTeams] = useState([]);
   // prevents re-rendering of teams on other state change (useful when teams is expensive)
@@ -26,7 +27,7 @@ export default function UploadVideo() {
     fetchTeams();
   }, []);
 
-  const handleSubmit = async (e) => {
+  const handleUploadSubmit = async (e) => {
     e.preventDefault();
     
     if (!teamName || !logoFile) {
@@ -36,6 +37,22 @@ export default function UploadVideo() {
     
     try {
       await uploadTeam(teamName, logoFile)
+      alert('done!')
+    } catch (error) {
+      console.error("Error uploading match:", error);
+    }
+  };
+
+  const handleAddSubmit = async (e) => {
+    e.preventDefault();
+    
+    if (!playerName) {
+      console.error("Please fill in Player Name.");
+      return;
+    }
+    
+    try {
+      await uploadPlayer(playerName)
       alert('done!')
     } catch (error) {
       console.error("Error uploading match:", error);
@@ -54,7 +71,7 @@ export default function UploadVideo() {
       </div>
       <div>
         <h1 className={styles.title}>Add Team</h1>
-        <form className={styles.form} onSubmit={handleSubmit}>
+        <form className={styles.form} onSubmit={handleUploadSubmit}>
           <label>
             Team Name: 
             <input type="text" value={teamName} onChange={(e) => setTeamName(e.target.value)} />
@@ -64,6 +81,16 @@ export default function UploadVideo() {
             <input type="file" accept="image/png, image/jpeg" onChange={(e) => setLogoFile(e.target.files[0])} />
           </label>
           <button type="submit">Upload</button>
+        </form>
+      </div>
+      <div>
+        <h1 className={styles.title}>Add Player</h1>
+        <form className={styles.form} onSubmit={handleAddSubmit}>
+          <label>
+            Player Name: 
+            <input type="text" value={teamName} onChange={(e) => setTeamName(e.target.value)} />
+          </label>
+          <button type="submit">Add</button>
         </form>
       </div>
     </div>

--- a/app/(interactive)/upload-team/page.js
+++ b/app/(interactive)/upload-team/page.js
@@ -88,7 +88,7 @@ export default function UploadVideo() {
         <form className={styles.form} onSubmit={handleAddSubmit}>
           <label>
             Player Name: 
-            <input type="text" value={teamName} onChange={(e) => setTeamName(e.target.value)} />
+            <input type="text" value={teamName} onChange={(e) => setPlayerName(e.target.value)} />
           </label>
           <button type="submit">Add</button>
         </form>

--- a/app/services/getTeams.js
+++ b/app/services/getTeams.js
@@ -2,7 +2,7 @@ import { db } from '../services/initializeFirebase.js'; // Ensure storage is exp
 import { collection, getDocs } from 'firebase/firestore';
 
 
-const getLogos = async() => {
+const getTeams = async() => {
   try {
     const querySnapshot = await getDocs(collection(db, 'teams'));
     const teams = querySnapshot.docs.map((doc) => doc.data());
@@ -14,4 +14,4 @@ const getLogos = async() => {
   }
 };
 
-export default getLogos;
+export default getTeams;

--- a/app/services/upload.js
+++ b/app/services/upload.js
@@ -2,8 +2,8 @@ import { collection, addDoc, query, where, getDoc, getDocs, updateDoc, doc, arra
 import { ref, uploadBytes, getDownloadURL } from "firebase/storage"; // Import storage functions
 import { db, storage } from '../services/initializeFirebase.js'; // Ensure storage is exported from initializeFirebase.js
 
-async function uploadMatch(matchName, videoId, pointsJson, pdfFile, clientTeam, opponentTeam) {
-  if (!matchName || !videoId || !clientTeam || !opponentTeam) {
+async function uploadMatch(matchScore, videoId, pointsJson, pdfFile, teams, players, matchDate, singles) {
+  if (!matchScore || !videoId || !teams || !players || !matchDate || !singles) {
     console.error("All fields are required.");
     return; // Exit the function if any field is empty
   }
@@ -21,15 +21,21 @@ async function uploadMatch(matchName, videoId, pointsJson, pdfFile, clientTeam, 
     let published = true;
     if (pointsJson === null) published = false;
 
-    // Then, save the match data along with the PDF URL to Firestore
-    const docRef = await addDoc(collection(db, "matches"), {
+    // matchName: P1 T1 vs. P2 T2
+    const matchName = players[0] + " " + teams[0] + " vs. " + players[1] + " " + teams[1]
+    // only save match to clientTeam because we will never need to use matches by opponentTeam. 
+    // Every client should only see their own matches: we upload UCLA vs USC, USC should not be able to see that.
+    const docRef = await addDoc(collection(db, teams[0]), {
       name: matchName,
-      videoId: videoId,
-      points: pointsJson? pointsJson : [],
-      pdfUrl: pdfUrl,
-      clientTeam,
-      opponentTeam,
-      published
+      videoId,
+      matchScore,
+      pdfUrl,
+      matchDate,
+      teams,
+      players,
+      published,
+      singles,
+      points: pointsJson? pointsJson : []
     });
     console.log("Match Document written with ID: ", docRef.id);
     

--- a/app/services/upload.js
+++ b/app/services/upload.js
@@ -59,10 +59,12 @@ async function uploadTeam(teamName, logoFile) {
     const docRefM = await addDoc(collection(db, "teams"), {
       name: mens,
       logoUrl: logoUrl,
+      players: []
     });
     const docRefW = await addDoc(collection(db, "teams"), {
       name: womens,
       logoUrl: logoUrl,
+      players: []
     });
     console.log("Team Document(M) written with ID: ", docRefM.id, " and (W): ", docRefW.id);
     
@@ -95,6 +97,7 @@ async function uploadPlayer(playerName, teamName) {
     const teamData = (await getDoc(teamDoc)).data();
     if (!teamData.players) {
       // If 'players' field doesn't exist, create it and initialize it as an array
+      // backwards support for old storage schema
       await updateDoc(teamDoc, { players: [playerName] });
     } else {
       // If 'players' field exists, append the playerName to the array


### PR DESCRIPTION
sent to the web dev team for transitioning: 
"as we transition into new features, we’ve reformatted the firebase. The matches collection is for backwards support (holds all matches in it/what we have right now). The teams collection holds info about all teams + their logo locations (use this for rostering, kevin). UCLA (W) collection represents that UCLA (W) is our ‘client team’ and this holds all UCLA (W) matches. 

Refer to this format when developing your new features! Specifically, the new dashboard will likely be grouping matches by the ‘date’ field (will/tom) and use the ‘singles’ field for displaying singles vs doubles matches (alex-c/rit)"


![Untitled (Draft)](https://github.com/awest25/Tennis-Video-Viewer/assets/40157329/e5fbc4e5-134e-45c8-bc65-fe951c9ddbf0)
<img width="888" alt="image" src="https://github.com/awest25/Tennis-Video-Viewer/assets/40157329/b8b2df8d-fe46-4f9d-af16-57d5d420f700">
<img width="1382" alt="image" src="https://github.com/awest25/Tennis-Video-Viewer/assets/40157329/9cbbcb4d-f9b2-43ff-87ed-0d989c7d0174">
<img width="1151" alt="IMG_0194" src="https://github.com/awest25/Tennis-Video-Viewer/assets/40157329/3bffc2e7-5dad-46e1-a821-c8f555688886">
<img width="1141" alt="IMG_4737" src="https://github.com/awest25/Tennis-Video-Viewer/assets/40157329/4c057790-00b5-4119-8958-42b49263c45a">
