### PR TITLE
Fixed issues with ghost value and percentages

### DIFF
--- a/app/components/FilterList.js
+++ b/app/components/FilterList.js
@@ -51,7 +51,7 @@ const FilterList = ({ pointsData, filterList, setFilterList, showPercent, showCo
   const countFilteredPointsTotal = (key) => {
     return pointsData.reduce((total, point) => {
       // Check if the value attribute is not an empty string
-      if (point[key] !== '') {
+      if (point[key] !== '' && point[key] !== null) {
         return total + 1; // Add 1 to the total if this point has a value specific to this category (key)
       }
       // Otherwise, just return the current total without adding anything
@@ -83,7 +83,7 @@ const FilterList = ({ pointsData, filterList, setFilterList, showPercent, showCo
                   <ul className={styles.filterValuesList} style={{ display: openKey === key ? 'block' : 'none' }}>
                     {/* { console.log(uniqueValues)} */}
                     {uniqueValues[key].map((value) => (
-                      value !== '' && (
+                      value !== '' && value !== null && (
                         <div className={styles.filterValueItem} key={value} style={{
                           cursor: 'pointer',
                           backgroundColor: isActiveFilter(key, value) ? '#8BB8E8' : ''


### PR DESCRIPTION
bug resulted because empty values in new matches are null, while empty values in old matches are tagged with ""
<img width="529" alt="Screenshot 2024-05-03 at 12 29 06
<img width="529" alt="Screenshot 2024-05-03 at 12 29 06 PM" src="https://github.com/awest25/Tennis-Video-Viewer/assets/157664435/fd700e37-d626-4454-8ee7-0bb87f4484dd">
<img width="529" alt="Screenshot 2024-05-03 at 12 27 42 PM" src="https://github.com/awest25/Tennis-Video-Viewer/assets/157664435/ad4dd0ec-505c-40e6-bc69-73f1f208cb1b">
<img width="346" alt="Screenshot 2024-05-03 at 12 27 23 PM" src="https://github.com/awest25/Tennis-Video-Viewer/assets/157664435/d6115dd3-72c4-4226-9c7f-2f780773c75d">
 PM" src="https://github.com/awest25/Tennis-Video-Viewer/assets/157664435/75e95964-a047-4ab5-8439-a00c018c422d">
