### PR TITLE
Fix Password from demo to demo123

### DIFF
--- a/app/components/SignIn.js
+++ b/app/components/SignIn.js
@@ -80,7 +80,7 @@ const SignInPage = () => {
               {/* add contact details */}
               <p>To demo this page, use:</p>
               <ul>Username: demo</ul>
-              <ul>Password: demo</ul>
+              <ul>Password: demo123</ul>
             </div>
           </div>
         </form>


### PR DESCRIPTION
Firebase did not allow a password shorter than 6 characters. Secondly, the demo account seemed to have been removed over the summer so I created that again recently. 