### PR TITLE
adding filters

### DIFF
--- a/app/components/FilterList.js
+++ b/app/components/FilterList.js
@@ -5,6 +5,15 @@ import styles from '../styles/FilterList.module.css'
 // This file renammes columns to more human-readable names
 import nameMap from '../services/nameMap.js'
 
+const exclusiveGroups = {
+  player1ReturnFhBh: ['Forehand', 'Backhand'],
+  player1ReturnPlacement: ['Down the Line', 'Crosscourt'],
+  player1LastShotResult: ['Winner', 'Error'],
+  player1LastShotFhBh: ['Forehand', 'Backhand'],
+  player1LastShotPlacement: ['Down the Line', 'Crosscourt'],
+  side: ['Deuce', 'Ad']
+}
+
 const FilterList = ({
   pointsData,
   filterList,
@@ -50,7 +59,13 @@ const FilterList = ({
       ([filterKey, filterValue]) => filterKey === key && filterValue === value
     )
     if (!isDuplicate) {
-      setFilterList([...filterList, [key, value]])
+      const group = Object.values(exclusiveGroups).find((group) =>
+        group.includes(value)
+      )
+      const updatedFilterList = filterList.filter(
+        ([filterKey, filterValue]) => !(group && group.includes(filterValue))
+      )
+      setFilterList([...updatedFilterList, [key, value]])
     }
   }
   const removeFilter = (key, value) => {


### PR DESCRIPTION
### One Filter at a Time #149 

For certain filters, there will only be one active filter at a time. Filters that are deactivated:

`player1ReturnFhBh: ['Forehand', 'Backhand']`
 `player1ReturnPlacement: ['Down the Line', 'Crosscourt']`
 `player1LastShotResult: ['Winner', 'Error']`
 `player1LastShotFhBh: ['Forehand', 'Backhand']`
 `player1LastShotPlacement: ['Down the Line', 'Crosscourt']`
 `side: ['Deuce', 'Ad']`
 
 ### changes: only in FilterList.js
 Adding exclusive list
<img width="463" alt="Screenshot 2024-10-21 at 6 41 24 PM" src="https://github.com/user-attachments/assets/e333e8c6-bd8b-43b2-b464-50b672a4f793">

Change to addFilter
<img width="590" alt="Screenshot 2024-10-21 at 6 41 50 PM" src="https://github.com/user-attachments/assets/f62801e0-f68e-424f-81f9-eb787de10808">

When adding filter, check if its in exclusive list, and remove other option

**Possibly:** add exlusiveGroups to a service or nameMap

 